### PR TITLE
Fix explore tab

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,22 +1,4 @@
 class PagesController < ApplicationController
-  # GET /explore
-  def explore_visualizations
-    @items = Visualization.published.order(created_at: :desc)
-    @items = @items.search(params[:search]) if params[:search].present?
-    #@items = @items.order("published_at DESC").includes(:photo).page(params[:page]).per(9)
-    @items = @items.page(params[:page]).per(6)
-    @show_visualizations = true
-    render :explore
-  end
-
-  def explore_stories
-    @items = Story.published.order(created_at: :desc)
-    @items = @items.search(params[:search]) if params[:search].present?
-    @items = @items.page(params[:page]).per(6)
-    @show_visualizations = false
-    render :explore
-  end
-
   # GET /gallery
   def gallery
     gallery = Gallery.instance

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -12,8 +12,6 @@
       - else
         %a.btn.btn-primary{:href => new_visualization_path, :title => t('.create_visualization')}
           = t '.create_visualization'
-      %a.btn.btn-primary{:href => "/explore", :title => t('.explore')}
-        = t '.explore'
       %a.btn.btn-primary{:href => "/demo", :title => t('.demo')}
         = t '.demo'
       /%a.btn.btn-primary{:href => "/gallery", :title => t('.gallery')}

--- a/app/views/partials/_footer.html.haml
+++ b/app/views/partials/_footer.html.haml
@@ -12,9 +12,6 @@
         .row
           %ul.col-sm-6
             %li
-              %a{href: "/explore"}
-                = t 'common.explore'
-            %li
               %a{href: "/gallery"}
                 = t 'common.gallery'
             %li

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -12,9 +12,6 @@
     #navbar.navbar-collapse.collapse
       %ul.nav.navbar-nav
         %li
-          %a{:href => "/explore", :class => ('active' unless controller.controller_name != 'pages' or controller.action_name != 'explore')}
-            =t 'common.explore'
-        %li
           %a{:href => "/gallery", :class => ('active' unless controller.controller_name != 'pages' or controller.action_name != 'gallery')}
             =t 'common.gallery'
         %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,9 +66,6 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/explore'                 => 'pages#explore_visualizations'
-  get '/explore/visualizations/' => 'pages#explore_visualizations'
-  get '/explore/stories/'        => 'pages#explore_stories'
   get '/gallery'                 => 'pages#gallery'
 
   get   '/gallery/edit', to: 'galleries#edit', as: :edit_gallery


### PR DESCRIPTION
Añado una lista con los cambios propuestos @dcabo :

- Eliminar el enlace _explore_ y el botón en `index.html.haml`
- Eliminar las rutas de la pestaña _explore_ en `routes.rb`

No he eliminado de momento los métodos `explore_visualizations` y `explore_stories` de la clase [`pages_controller.rb`](https://github.com/civio/onodo/blob/master/app/controllers/pages_controller.rb)